### PR TITLE
Fix zero length matrix transpose

### DIFF
--- a/extension/utils.ts
+++ b/extension/utils.ts
@@ -15,7 +15,7 @@ export function ensureBuffer(chunk: Buffer | string): Buffer {
   return Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
 }
 
-const T = (A: number[][]): number[][] => A[0].map((_, i) => A.map((a) => a[i]));
+const T = (A: number[][]): number[][] => A[0]?.map((_, i) => A.map((a) => a[i])) || [];
 const dotVV = (a: number[], b: number[]): number => a.map((x, i) => a[i] * b[i]).reduce((m, n) => m + n);
 const dotMV = (A: number[][], b: number[]): number[] => A.map((a) => dotVV(a, b));
 const dotMM = (A: number[][], B:number[][]): number[][] => A.map((a) => dotMV(T(B), a));


### PR DESCRIPTION
Transpose was broken for zero length 2D matrices. `T([])` now returns `[]` instead of throwing an exception.

This fixes #30 ... partially. It can now open the files without crashing and displays (as far as I can see) the correct dimensions. But the images themselves do not seem to be displayed properly.

[Here is an example file to replicate this](https://github.com/anibalsolon/vscode-neuro-viewer/files/9944276/sub-0025429_ses-1_from-template_to-T1w_mode-image_desc-nonlinear_xfm.nii.gz)

(Source: C-PAC_Derivatives\preproc\output\cpac_cpac_preproc\sub-0025429_ses-1\anat\sub-0025429_ses-1_from-template_to-T1w_mode-image_desc-nonlinear_xfm.nii.gz from https://osf.io/syqvc/ with permission. Thanks @gkiar !)

vscode-neuro-viewer:

![image](https://user-images.githubusercontent.com/33600480/200131218-597ae0fd-1830-4923-85cb-e33a279817b1.png)


Other viewers (i.e. MRIcroGL):

![image](https://user-images.githubusercontent.com/33600480/200131048-c0a52422-8f41-4425-9871-fa3cf196a955.png)

